### PR TITLE
Use full identifiers instead of just the path

### DIFF
--- a/src/main/java/org/agmas/harpymodloader/commands/ForceRoleCommand.java
+++ b/src/main/java/org/agmas/harpymodloader/commands/ForceRoleCommand.java
@@ -7,6 +7,7 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import dev.doctor4t.trainmurdermystery.api.Role;
 import dev.doctor4t.trainmurdermystery.api.TMMRoles;
 import net.minecraft.command.argument.EntityArgumentType;
+import net.minecraft.command.argument.IdentifierArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -22,9 +23,9 @@ public class ForceRoleCommand {
                 .requires(serverCommandSource -> serverCommandSource.hasPermissionLevel(2))
                 .then(CommandManager.argument("player", EntityArgumentType.player())
                         .executes(context -> query(context.getSource(), EntityArgumentType.getPlayer(context, "player")))
-                .then(CommandManager.argument("role", StringArgumentType.string())
+                .then(CommandManager.argument("role", IdentifierArgumentType.identifier())
                         .suggests(new RoleSuggestionProvider())
-                        .executes(context -> execute(context.getSource(), EntityArgumentType.getPlayer(context,"player"), StringArgumentType.getString(context,"role"))))));
+                        .executes(context -> execute(context.getSource(), EntityArgumentType.getPlayer(context,"player"), IdentifierArgumentType.getIdentifier(context,"role").toString())))));
     }
     private static int query(ServerCommandSource source, ServerPlayerEntity targetPlayer) {
         if (!Harpymodloader.FORCED_MODDED_ROLE_FLIP.containsKey(targetPlayer.getUuid())) {
@@ -38,7 +39,7 @@ public class ForceRoleCommand {
     }
     private static int execute(ServerCommandSource source, ServerPlayerEntity targetPlayer, String roleName) throws CommandSyntaxException {
         for (Role role : TMMRoles.ROLES) {
-            if (role.identifier().getPath().equals(roleName)) {
+            if (role.identifier().toString().equals(roleName)) {
                 Harpymodloader.addToForcedRoles(role,targetPlayer);
                 source.sendFeedback(() -> Text.translatable("commands.forcerole.success", Text.literal(roleName).withColor(role.color()), targetPlayer.getDisplayName()), true);
                 return 1;

--- a/src/main/java/org/agmas/harpymodloader/commands/ListRolesCommand.java
+++ b/src/main/java/org/agmas/harpymodloader/commands/ListRolesCommand.java
@@ -21,7 +21,7 @@ public class ListRolesCommand {
         Text disabled = Text.literal("[Disabled] ").withColor(Colors.RED);
         for (Role role : TMMRoles.ROLES) {
             message.append("\n");
-            String roleName = role.identifier().getPath();
+            String roleName = role.identifier().toString();
             if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(roleName)) message.append(disabled);
             else message.append(enabled);
             message.append(Text.literal(roleName).withColor(role.color()));

--- a/src/main/java/org/agmas/harpymodloader/commands/SetEnabledRoleCommand.java
+++ b/src/main/java/org/agmas/harpymodloader/commands/SetEnabledRoleCommand.java
@@ -9,6 +9,7 @@ import dev.doctor4t.trainmurdermystery.api.Role;
 import dev.doctor4t.trainmurdermystery.api.TMMRoles;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
+import net.minecraft.command.argument.IdentifierArgumentType;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
@@ -23,14 +24,14 @@ public class SetEnabledRoleCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(CommandManager.literal("setEnabledRole")
                 .requires(serverCommandSource -> serverCommandSource.hasPermissionLevel(2))
-                .then(CommandManager.argument("role", StringArgumentType.string()).suggests(new RoleSuggestionProvider())
+                .then(CommandManager.argument("role", IdentifierArgumentType.identifier()).suggests(new RoleSuggestionProvider())
                 .then(CommandManager.argument("enabled", BoolArgumentType.bool())
-                .executes(context -> execute(context.getSource(), StringArgumentType.getString(context, "role"), BoolArgumentType.getBool(context, "enabled"))))));
+                .executes(context -> execute(context.getSource(), IdentifierArgumentType.getIdentifier(context, "role").toString(), BoolArgumentType.getBool(context, "enabled"))))));
     }
     private static int execute(ServerCommandSource source, String roleName, boolean enabled) throws CommandSyntaxException {
         HarpyModLoaderConfig.HANDLER.save();
         for (Role role : TMMRoles.ROLES) {
-            if (role.identifier().getPath().equals(roleName)) {
+            if (role.identifier().toString().equals(roleName)) {
                 boolean disabled = HarpyModLoaderConfig.HANDLER.instance().disabled.contains(roleName);
                 Text roleText = Text.literal(roleName).withColor(role.color());
 

--- a/src/main/java/org/agmas/harpymodloader/commands/suggestions/RoleSuggestionProvider.java
+++ b/src/main/java/org/agmas/harpymodloader/commands/suggestions/RoleSuggestionProvider.java
@@ -22,8 +22,8 @@ public class RoleSuggestionProvider implements SuggestionProvider<ServerCommandS
 
         for (Role role : TMMRoles.ROLES) {
             if (Harpymodloader.VANNILA_ROLES.contains(role)) continue;
-            if (role != null && CommandSource.shouldSuggest(builder.getRemaining(), role.identifier().getPath())) {
-                builder.suggest(role.identifier().getPath());
+            if (role != null && CommandSource.shouldSuggest(builder.getRemaining(), role.identifier().toString())) {
+                builder.suggest(role.identifier().toString());
             }
         }
         return builder.buildFuture();

--- a/src/main/java/org/agmas/harpymodloader/modded_murder/ModdedMurderGameMode.java
+++ b/src/main/java/org/agmas/harpymodloader/modded_murder/ModdedMurderGameMode.java
@@ -81,12 +81,12 @@ public class ModdedMurderGameMode extends MurderGameMode {
         int neutralRoleCount = 0;
 
         for (Role role : shuffledNeutralRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             neutralRoleCount++;
         }
 
         for (Role role : shuffledNeutralRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             if (assignedNeutralRoles >= neutralDesiredRoleCount) continue;
             int roleSpecificDesireCount = Math.min((int) Math.ceil((double) playersForCivillianRoles.size() / neutralRoleCount), desiredRoleCount);
             if (Harpymodloader.ROLE_MAX.containsKey(role.identifier())) roleSpecificDesireCount = Harpymodloader.ROLE_MAX.get(role.identifier());
@@ -105,12 +105,12 @@ public class ModdedMurderGameMode extends MurderGameMode {
 
         int roleCount= 0;
         for (Role role : shuffledCivillianRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             roleCount++;
         }
 
         for (Role role : shuffledCivillianRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             int roleSpecificDesireCount = Math.min((int) Math.max(Math.round((double) playersForCivillianRoles.size() / roleCount),1), desiredRoleCount);
             if (Harpymodloader.ROLE_MAX.containsKey(role.identifier())) roleSpecificDesireCount = Harpymodloader.ROLE_MAX.get(role.identifier());
 
@@ -141,11 +141,11 @@ public class ModdedMurderGameMode extends MurderGameMode {
 
         int roleCount= 0;
         for (Role role : shuffledKillerRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             roleCount++;
         }
         for (Role role : shuffledKillerRoles) {
-            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().getPath())) continue;
+            if (HarpyModLoaderConfig.HANDLER.instance().disabled.contains(role.identifier().toString())) continue;
             int roleSpecificDesireCount = Math.min((int) Math.max(Math.round((double) playersForKillerRoles.size() / roleCount),1), desiredRoleCount);
             if (Harpymodloader.ROLE_MAX.containsKey(role.identifier())) roleSpecificDesireCount = Harpymodloader.ROLE_MAX.get(role.identifier());
 


### PR DESCRIPTION
For multiple mods that use the same path, so we don't disable all roles that use the same path.

For example, if Mod A created an Executioner and Mod B also created it's own take on Executioner, it would be under mod_a:executioner and mod_b:executioner. The problem is, HarpyModLoader right now only considers the path of the identifier rather than the full identifier, meaning excluding only one mod's executioner is impossible.

This PR hopes to fix that by changing the command arguments to Identifiers, rather than Strings.